### PR TITLE
Removing non-relevant option ( --skip-xlogs)

### DIFF
--- a/doc/omnipitr-backup-slave.pod
+++ b/doc/omnipitr-backup-slave.pod
@@ -156,11 +156,6 @@ seperated list to use multiple digest algorithms.
 
 For details please check L<CHECKSUMMING> below.
 
-=item --skip-xlogs (-sx)
-
-Make I<omnipitr-backup-master> skip creation of xlog tarball - only data
-tarball will be created. This is useful if you have set proper walarchive.
-
 =item --gzip-path (-gp)
 
 Full path to gzip program - in case you can't set proper PATH environment


### PR DESCRIPTION
omnipitr-backup-slave document shout not list --skip-xlogs as it's omnipitr-backup-master option. 