### PR TITLE
Support archiving WAL files with .partial suffix

### DIFF
--- a/lib/OmniPITR/Program/Archive.pm
+++ b/lib/OmniPITR/Program/Archive.pm
@@ -416,7 +416,7 @@ sub validate_args {
     }
 
     $self->log->fatal( 'Given segment name is not valid (%s)', $self->{ 'segment' } )
-        unless basename( $self->{ 'segment' } ) =~ m{\A(?:[a-fA-F0-9]{24}(?:\.[a-fA-F0-9]{8}\.backup)?|[a-fA-F0-9]{8}\.history)\z};
+        unless basename( $self->{ 'segment' } ) =~ m{\A(?:[a-fA-F0-9]{24}(?:\.[a-fA-F0-9]{8}\.backup|\.partial)?|[a-fA-F0-9]{8}\.history)\z};
     my $segment_file_name = $self->{ 'segment' };
     $segment_file_name = File::Spec->catfile( $self->{ 'data-dir' }, $self->{ 'segment' } ) unless $self->{ 'segment' } =~ m{^/};
 

--- a/lib/OmniPITR/Program/Cleanup.pm
+++ b/lib/OmniPITR/Program/Cleanup.pm
@@ -165,7 +165,7 @@ path), which is the default.
 sub validate_args {
     my $self = shift;
 
-    $self->log->fatal( 'Given segment name is not valid (%s)', $self->{ 'segment' } ) unless $self->{ 'segment' } =~ m{\A([a-fA-F0-9]{24}(?:\.[a-fA-F0-9]{8}\.backup)?|[a-fA-F0-9]{8}\.history)\z};
+    $self->log->fatal( 'Given segment name is not valid (%s)', $self->{ 'segment' } ) unless $self->{ 'segment' } =~ m{\A(?:[a-fA-F0-9]{24}(?:\.[a-fA-F0-9]{8}\.backup|\.partial)?|[a-fA-F0-9]{8}\.history)\z};
 
     $self->log->fatal( 'Given archive (%s) is not a directory', $self->{ 'archive' }->{ 'path' } ) unless -d $self->{ 'archive' }->{ 'path' };
     $self->log->fatal( 'Given archive (%s) is not readable',    $self->{ 'archive' }->{ 'path' } ) unless -r $self->{ 'archive' }->{ 'path' };


### PR DESCRIPTION
PostgreSQL 9.5 now tries to archive the last WAL before its new timeline creation with the .partial suffix. The sanity check in omnipitr tools leads to an archiving error.

This humble PR fix this issue.

Regards,